### PR TITLE
Update main.css

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -95,14 +95,16 @@ footer a {
 .btn-ceremonial {
     background-color: white;
     border: none;
-    height: 200px;
+    height: 160px;
+    margin: 20px 0;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+    width: 100%;
+    border-radius: 10px;
+    transition: all 0.3s;
 }
 .btn-ceremonial:hover {
-    box-shadow: 0 12px 16px 0 rgba(0,0,0,0.24), 0 17px 50px 0 rgba(0,0,0,0.19);
-    width:100%;
-    border-radius: 10px;
-    background-color: #2B2B2B;
-    color: aliceblue;
+    box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+
 }
 .btn-ceremonial h4 {
     font-size: 1.4em;


### PR DESCRIPTION
And here is a third option. What I've done here is remove the color fill (and the Army removed the connection to your CDN, so, good job, Army, I didn't need icon fonts for more than ten minutes anyway) and add a transition. This way the piece feels more natural as it raises off the page. It shouldn't snap instantly. Our minds don't understand that movement.

Also, I pushed some of the hover styles into the default style. Hovers are for changing things. That's why, before, your width would jump from whatever it was to 100%.

Transitions work the same way. You put the transition on the default style, and it uses that information to move between changes. In this case, your box shadow is changing between regular and :hover states. The transition slows this down to make awesome happen.

Enjoy!
